### PR TITLE
Ignore some storage slots

### DIFF
--- a/src/occ.rs
+++ b/src/occ.rs
@@ -155,10 +155,11 @@ pub fn batches(txs: &Vec<TransactionInfo>, gas: &Vec<U256>, batch_size: usize) -
 pub fn thread_pool(txs: &Vec<TransactionInfo>, gas: &Vec<U256>, num_threads: usize) -> U256 {
     assert_eq!(txs.len(), gas.len());
 
-    let mut exceptions = HashSet::new();
-    exceptions.insert("0x06012c8cf97bead5deae237070f9587f8e7a266d-0x000000000000000000000000000000000000000000000000000000000000000f");
-    exceptions.insert("0x06012c8cf97bead5deae237070f9587f8e7a266d-0x0000000000000000000000000000000000000000000000000000000000000006");
-    exceptions.insert("0x06012c8cf97bead5deae237070f9587f8e7a266d-0xc56c286245a85e4048e082d091c57ede29ec05df707b458fe836e199193ff182");
+    #[allow(unused_mut)]
+    let mut ignored_slots: HashSet<&str> = Default::default();
+    // ignored_slots.insert("0x06012c8cf97bead5deae237070f9587f8e7a266d-0x000000000000000000000000000000000000000000000000000000000000000f");
+    // ignored_slots.insert("0x06012c8cf97bead5deae237070f9587f8e7a266d-0x0000000000000000000000000000000000000000000000000000000000000006");
+    // ignored_slots.insert("0x06012c8cf97bead5deae237070f9587f8e7a266d-0xc56c286245a85e4048e082d091c57ede29ec05df707b458fe836e199193ff182");
 
     type MinHeap<T> = BinaryHeap<Reverse<T>>;
 
@@ -263,7 +264,7 @@ pub fn thread_pool(txs: &Vec<TransactionInfo>, gas: &Vec<U256>, num_threads: usi
                 for acc in accesses.iter().filter(|a| a.mode == AccessMode::Read) {
                     if let Target::Storage(addr, entry) = &acc.target {
                         if concurrent.contains(&Access::storage_write(addr, entry)) {
-                            if !exceptions.contains(&format!("{}-{}", addr, entry)[..]) {
+                            if !ignored_slots.contains(&format!("{}-{}", addr, entry)[..]) {
                                 aborted = true;
                                 break 'outer;
                             }


### PR DESCRIPTION
We ignore storage slots whose conflicts are actually commutative operations (e.g. increment).